### PR TITLE
add weights to triangulation

### DIFF
--- a/multicam_calibration/geometry.py
+++ b/multicam_calibration/geometry.py
@@ -376,6 +376,7 @@ def triangulate(all_uvs, all_extrinsics, all_intrinsics, weights=None):
             # if none, skip
             if np.all(valid_pt_mask == False):
                 robust_points.append([np.nan, np.nan, np.nan])
+                continue
 
             # weight each pairwise triangulation
             pt_weights = np.array(


### PR DESCRIPTION
allows median across cameras to be computed with weights corresponding to which camera angles matter more